### PR TITLE
Added typescript typings for moment-holiday

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Added
+- `moment-holiday.d.ts` typescript typings.
 
 ## [1.5.1] - 2017-08-03
 ### Removed

--- a/moment-holiday.d.ts
+++ b/moment-holiday.d.ts
@@ -2,11 +2,17 @@ import * as moment from 'moment';
 
 declare module 'moment' {
     interface Moment extends Object {
-        holiday(holidays?: Array<string> | string, adjust?: boolean): Moment | false | { [holidayName: string]: Moment }
+        holiday(
+            holidays?: Array<string> | string,
+            adjust?: boolean): Moment | false | { [holidayName: string]: Moment }
 
-        holidays(holidays?: Array<string> | string, adjust?: boolean): Moment | false | { [holidayName: string]: Moment }
+        holidays(
+            holidays?: Array<string> | string,
+            adjust?: boolean): Moment | false | { [holidayName: string]: Moment }
 
-        isHoliday(holidays?: Array<string> | string | null, adjust?: boolean): boolean | string | Array<string>
+        isHoliday(
+            holidays?: Array<string> | string | null,
+            adjust?: boolean): boolean | string | Array<string>
 
         previousHoliday(count?: number, adjust?: boolean): Array<Moment> | Moment;
 
@@ -19,23 +25,40 @@ declare module 'moment' {
         holidaysBetween(m: Moment, adjust?: boolean): Array<Moment> | false;
     }
 
+    interface IHolidayDefinition {
+        date: string;
+        keywords?: Array<string>;
+        keywords_y?: Array<string>;
+        keywords_n?: Array<string>;
+        regions?: Array<string>;
+        regions_n?: Array<string>;
+    }
+
+    interface IHolidaysMapping {
+        [holidayName: string]: IHolidayDefinition;
+    }
+
     interface IHolidays {
-        active: any;
-        active_last: any;
+        active: IHolidaysMapping;
+        active_last: IHolidaysMapping;
     }
 
     interface IHolidayModifier {
-        set(holidays: any, specifics?: any): IHolidayModifier;
+        set(
+            holidays: IHolidaysMapping | string | Array<string>,
+            specifics?: any): IHolidayModifier;
 
-        add(holidays: any, specifics?: any): IHolidayModifier;
+        add(
+            holidays: IHolidaysMapping | string,
+            specifics?: any): IHolidayModifier;
 
-        remove(holidays: any): IHolidayModifier;
+        remove(holidays: string | Array<string>): IHolidayModifier;
 
         undo(): IHolidayModifier;
 
-        load(locales: any): IHolidayModifier;
+        load(locales: string | Array<string>): IHolidayModifier;
 
-        extendParser(parserFunc: (m: Moment, date: string) => any): IHolidayModifier;
+        extendParser(parserFunc: (m: Moment, date: string) => moment.Moment | Array<moment.Moment> | false | void): IHolidayModifier;
     }
 
     export var holidays: IHolidays;

--- a/moment-holiday.d.ts
+++ b/moment-holiday.d.ts
@@ -1,0 +1,43 @@
+import * as moment from 'moment';
+
+declare module 'moment' {
+    interface Moment extends Object {
+        holiday(holidays?: Array<string> | string, adjust?: boolean): Moment | false | { [holidayName: string]: Moment }
+
+        holidays(holidays?: Array<string> | string, adjust?: boolean): Moment | false | { [holidayName: string]: Moment }
+
+        isHoliday(holidays?: Array<string> | string | null, adjust?: boolean): boolean | string | Array<string>
+
+        previousHoliday(count?: number, adjust?: boolean): Array<Moment> | Moment;
+
+        previousHolidays(count?: number, adjust?: boolean): Array<Moment> | Moment;
+
+        nextHoliday(count?: number, adjust?: boolean): Array<Moment> | Moment;
+
+        nextHolidays(count?: number, adjust?: boolean): Array<Moment> | Moment;
+
+        holidaysBetween(m: Moment, adjust?: boolean): Array<Moment> | false;
+    }
+
+    interface IHolidays {
+        active: any;
+        active_last: any;
+    }
+
+    interface IHolidayModifier {
+        set(holidays: any, specifics?: any): IHolidayModifier;
+
+        add(holidays: any, specifics?: any): IHolidayModifier;
+
+        remove(holidays: any): IHolidayModifier;
+
+        undo(): IHolidayModifier;
+
+        load(locales: any): IHolidayModifier;
+
+        extendParser(parserFunc: (m: Moment, date: string) => any): IHolidayModifier;
+    }
+
+    export var holidays: IHolidays;
+    export var modifyHolidays: IHolidayModifier;
+}

--- a/package.json
+++ b/package.json
@@ -35,9 +35,11 @@
   "homepage": "https://github.com/kodie/moment-holiday",
   "license": "MIT",
   "main": "./build/moment-holiday-us.min.js",
+  "types": "./moment-holiday.d.ts",
   "files": [
     "build/",
-    "locale/"
+    "locale/",
+    "moment-holiday.d.ts"
   ],
   "dependencies": {
     "moment": ">=2.0.0"
@@ -52,9 +54,11 @@
     "gulp-sourcemaps": ">=2.0.0",
     "gulp-uglify": ">=3.0.0",
     "jshint": ">=2.9.1",
+    "typescript": "^2.4.2",
     "yargs": ">=8.0.0"
   },
   "scripts": {
-    "test": "./node_modules/.bin/jshint *.js locale/*.js && ava"
+    "test": "./node_modules/.bin/jshint *.js locale/*.js && ava",
+    "typescript-test": "tsc --project typing-tests"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "yargs": ">=8.0.0"
   },
   "scripts": {
-    "test": "./node_modules/.bin/jshint *.js locale/*.js && ava",
-    "typescript-test": "tsc --project typing-tests"
+    "test": "./node_modules/.bin/jshint *.js locale/*.js && ava && tsc --project typing-tests"
   }
 }

--- a/typing-tests/moment-holiday-tests.ts
+++ b/typing-tests/moment-holiday-tests.ts
@@ -62,17 +62,66 @@ holidaysBetweenResult = moment().holidaysBetween(moment());
 holidaysBetweenResult = moment().holidaysBetween(moment(), false);
 holidaysBetweenResult = moment().holidaysBetween(moment(), true);
 
-let h: moment.IHolidays = moment.holidays;
-let a: any = moment.holidays.active;
-let al: any = moment.holidays.active_last;
+let holidayDefinition: moment.IHolidayDefinition = {
+    date: 'string'
+};
+holidayDefinition = {
+    date: 'string',
+    keywords: ['array'],
+};
+holidayDefinition = {
+    date: 'string',
+    keywords: ['array'],
+    keywords_n: ['array'],
+};
+holidayDefinition = {
+    date: 'string',
+    keywords: ['array'],
+    keywords_n: ['array'],
+    keywords_y: ['array'],
+};
+holidayDefinition = {
+    date: 'string',
+    keywords: ['array'],
+    keywords_n: ['array'],
+    keywords_y: ['array'],
+    regions: ['array'],
+};
+holidayDefinition = {
+    date: 'string',
+    keywords: ['array'],
+    keywords_n: ['array'],
+    keywords_y: ['array'],
+    regions: ['array'],
+    regions_n: ['array']
+};
 
-let mh: moment.IHolidayModifier = moment.modifyHolidays;
-mh = mh.set({});
-mh = mh.set({}, {});
-mh = mh.add({});
-mh = mh.add({}, {});
-mh = mh.remove({});
-mh = mh.undo();
-mh = mh.load({});
-mh = mh.extendParser((m: moment.Moment, d: string): any => {
+let holidays: moment.IHolidays = moment.holidays;
+let activeHolidays: moment.IHolidaysMapping = moment.holidays.active;
+activeHolidays = {
+    'Some holiday name': holidayDefinition
+};
+
+let lastActiveHolidays: moment.IHolidaysMapping = moment.holidays.active_last;
+lastActiveHolidays = {
+    'Some holiday name': holidayDefinition
+};
+
+let holidayModifier: moment.IHolidayModifier = moment.modifyHolidays;
+holidayModifier = holidayModifier.set('string');
+holidayModifier = holidayModifier.set(['array']);
+holidayModifier = holidayModifier.set(activeHolidays);
+holidayModifier = holidayModifier.set('string', {});
+holidayModifier = holidayModifier.set(['array'], {});
+holidayModifier = holidayModifier.set(activeHolidays, {});
+holidayModifier = holidayModifier.add(activeHolidays);
+holidayModifier = holidayModifier.add('string');
+holidayModifier = holidayModifier.add(activeHolidays, {});
+holidayModifier = holidayModifier.add('string', {});
+holidayModifier = holidayModifier.remove('string');
+holidayModifier = holidayModifier.remove(['array']);
+holidayModifier = holidayModifier.undo();
+holidayModifier = holidayModifier.load('string');
+holidayModifier = holidayModifier.load(['string']);
+holidayModifier = holidayModifier.extendParser((m: moment.Moment, d: string): moment.Moment | Array<moment.Moment> | false | void => {
 });

--- a/typing-tests/moment-holiday-tests.ts
+++ b/typing-tests/moment-holiday-tests.ts
@@ -1,0 +1,78 @@
+/// <reference path="../moment-holiday.d.ts" />
+import * as moment from 'moment';
+
+let holidayResult: moment.Moment | false | { [holidayName: string]: moment.Moment };
+holidayResult = moment().holiday([]);
+holidayResult = moment().holiday([], false);
+holidayResult = moment().holiday([], true);
+holidayResult = moment().holiday('string');
+holidayResult = moment().holiday('string', false);
+holidayResult = moment().holiday('string', true);
+holidayResult = moment().holiday(['array', 'of', 'strings']);
+holidayResult = moment().holiday(['array', 'of', 'strings'], false);
+holidayResult = moment().holiday(['array', 'of', 'strings'], true);
+
+holidayResult = moment().holidays([]);
+holidayResult = moment().holidays([], false);
+holidayResult = moment().holidays([], true);
+holidayResult = moment().holidays('string');
+holidayResult = moment().holidays('string', false);
+holidayResult = moment().holidays('string', true);
+holidayResult = moment().holidays(['array', 'of', 'strings']);
+holidayResult = moment().holidays(['array', 'of', 'strings'], false);
+holidayResult = moment().holidays(['array', 'of', 'strings'], true);
+
+let isHolidayResult: boolean | string | Array<string>;
+isHolidayResult = moment().isHoliday();
+isHolidayResult = moment().isHoliday([]);
+isHolidayResult = moment().isHoliday([], false);
+isHolidayResult = moment().isHoliday([], true);
+isHolidayResult = moment().isHoliday(['array', 'of', 'strings']);
+isHolidayResult = moment().isHoliday(['array', 'of', 'strings'], false);
+isHolidayResult = moment().isHoliday(['array', 'of', 'strings'], true);
+isHolidayResult = moment().isHoliday('string');
+isHolidayResult = moment().isHoliday('string', false);
+isHolidayResult = moment().isHoliday('string', true);
+isHolidayResult = moment().isHoliday(null);
+isHolidayResult = moment().isHoliday(null, false);
+isHolidayResult = moment().isHoliday(null, true);
+
+let previousHolidayResult: Array<moment.Moment> | moment.Moment;
+previousHolidayResult = moment().previousHoliday();
+previousHolidayResult = moment().previousHoliday(1);
+previousHolidayResult = moment().previousHoliday(1, false);
+previousHolidayResult = moment().previousHoliday(1, true);
+previousHolidayResult = moment().previousHolidays();
+previousHolidayResult = moment().previousHolidays(1);
+previousHolidayResult = moment().previousHolidays(1, false);
+previousHolidayResult = moment().previousHolidays(1, true);
+
+let nextHolidayResult: Array<moment.Moment> | moment.Moment;
+nextHolidayResult = moment().nextHoliday();
+nextHolidayResult = moment().nextHoliday(1);
+nextHolidayResult = moment().nextHoliday(1, false);
+nextHolidayResult = moment().nextHoliday(1, true);
+nextHolidayResult = moment().nextHolidays();
+nextHolidayResult = moment().nextHolidays(1);
+nextHolidayResult = moment().nextHolidays(1, false);
+nextHolidayResult = moment().nextHolidays(1, true);
+
+let holidaysBetweenResult: Array<moment.Moment> | false;
+holidaysBetweenResult = moment().holidaysBetween(moment());
+holidaysBetweenResult = moment().holidaysBetween(moment(), false);
+holidaysBetweenResult = moment().holidaysBetween(moment(), true);
+
+let h: moment.IHolidays = moment.holidays;
+let a: any = moment.holidays.active;
+let al: any = moment.holidays.active_last;
+
+let mh: moment.IHolidayModifier = moment.modifyHolidays;
+mh = mh.set({});
+mh = mh.set({}, {});
+mh = mh.add({});
+mh = mh.add({}, {});
+mh = mh.remove({});
+mh = mh.undo();
+mh = mh.load({});
+mh = mh.extendParser((m: moment.Moment, d: string): any => {
+});

--- a/typing-tests/tsconfig.json
+++ b/typing-tests/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "module": "commonjs",
+    "noEmit": true,
+    "noImplicitAny": true
+  },
+  "files": [
+    "../moment-holiday.d.ts",
+    "./moment-holiday-tests.ts"
+  ]
+}


### PR DESCRIPTION
Attempted to implement the typings and related tests in the same fashion that moment itself does.

Typings cover:

* extensions to moment objects such as `holiday`, `isHoliday`, and so on
* the `holidays` and `modifyHolidays` objects in the moment namespace

Also contains an npm script to ensure that the typings match expected usage.