### PR TITLE
Add "Erster Weihnachtsfeiertag" to german locale

### DIFF
--- a/locale/germany.js
+++ b/locale/germany.js
@@ -3,12 +3,17 @@
 //! author : Kodie Grantham : https://github.com/kodie
 /* regions :
       BB : Brandenburg
+      BE : Berlin
       BW : Baden-Württemberg
       BY : Bayern
+      HB : Bremen
       HE : Hessen
+      HH : Hamburg
       MV : Mecklenburg-Vorpommern
+      NI : Niedersachsen
       NW : Nordrhein-Westfalen
       RP : Rheinland-Pfalz
+      SH : Schleswig-Holstein
       SN : Sachsen
       SL : Saarland
       ST : Sachsen-Anhalt
@@ -87,6 +92,10 @@
     "Weihnachten": {
       date: '12/24',
       keywords: ['christmas']
+    },
+    "Erster Weihnachstfeiertag": {
+      date: '12/25',
+      keywords: ['erster']
     },
     "Zweiter Weihnachtsfeiertag": {
       date: '12/26',

--- a/locale/germany.js
+++ b/locale/germany.js
@@ -93,7 +93,7 @@
       date: '12/24',
       keywords: ['christmas']
     },
-    "Erster Weihnachstfeiertag": {
+    "Erster Weihnachtsfeiertag": {
       date: '12/25',
       keywords: ['erster']
     },


### PR DESCRIPTION
The first day after christmas is also a public holiday.

Also added the missing regions as it might be confusing if they are missing