### PR TITLE
12/24 is no holiday in germany, but 12/25 is

### DIFF
--- a/locale/germany.js
+++ b/locale/germany.js
@@ -84,8 +84,8 @@
       keywords: ['bub'],
       regions: ['sn']
     },
-    "Weihnachten": {
-      date: '12/24',
+    "Erster Weihnachtsfeiertag": {
+      date: '12/25',
       keywords: ['christmas']
     },
     "Zweiter Weihnachtsfeiertag": {


### PR DESCRIPTION
Also updated the name to reflect the correct "1. Weihnachtsfeiertag" or "Erster Weihnachtsfeiertag"