### PR TITLE
Update germany.js

### DIFF
--- a/locale/germany.js
+++ b/locale/germany.js
@@ -84,9 +84,13 @@
       keywords: ['bub'],
       regions: ['sn']
     },
-    "Weihnachten": {
+    "Heiligabend": {
       date: '12/24',
       keywords: ['christmas']
+    },
+    "Erster Weihnachtsfeiertag": {
+      date: '12/25',
+      keywords_y: ['erster']
     },
     "Zweiter Weihnachtsfeiertag": {
       date: '12/26',


### PR DESCRIPTION
* added first christmas holiday
* renamed `Weihnachten` to `Heiligabend` (12/24)

fyi: `Heiligabend` aka Christmas Eve is not an official holiday in germany