### PR TITLE
Fixed denmark locale (christmas holidays)

### DIFF
--- a/locale/denmark.js
+++ b/locale/denmark.js
@@ -42,8 +42,13 @@
       date: '12/24',
       keywords: ['christmas']
     },
-    "Anden juledag": {
+    "Juledag": {
       date: '12/25',
+      keywords: ['juledag'],
+      keywords_y: ['anden']
+    },
+    "Anden juledag": {
+      date: '12/26',
       keywords: ['andenjuledag'],
       keywords_y: ['anden']
     }

--- a/locale/denmark.js
+++ b/locale/denmark.js
@@ -10,6 +10,10 @@
       date: '1/1',
       keywords: ['nytarsdag', 'new', 'years']
     },
+    "Skærtorsdag": {
+      date: 'easter-3',
+      keywords: ['skaertorsdag', 'maundy', 'friday']
+    },
     "Skærfredag": {
       date: 'easter-2',
       keywords: ['skaerfredag', 'good', 'friday']
@@ -22,13 +26,13 @@
       date: 'easter+1',
       keywords: ['andenpåskedag', 'andenpaskedag', 'paskedag', 'easter', 'monday']
     },
-    "Første maj": {
-      date: '5/1',
-      keywords: ['førstemaj', 'forstemaj', 'forste', 'maj']
+    "Store bededag": {
+      date: 'easter+33',
+      keywords: ['great', 'prayer', 'day']
     },
     "Kristi himmelfart": {
       date: 'easter+39',
-      kaywords: ['ascension']
+      keywords: ['ascension']
     },
     "Pinse": {
       date: 'easter+49',

--- a/locale/denmark.js
+++ b/locale/denmark.js
@@ -45,7 +45,7 @@
     "Juledag": {
       date: '12/25',
       keywords: ['juledag'],
-      keywords_y: ['anden']
+      keywords_y: ['første']
     },
     "Anden juledag": {
       date: '12/26',


### PR DESCRIPTION
In Denmark the 24th is Christmas eve (Juleaften) 25th is "Christmas day" (juledag) and the 26th is "second Christmas day" (anden juledag).